### PR TITLE
Add validadores, ajustado dialogos

### DIFF
--- a/bot/actions/validate_slots.py
+++ b/bot/actions/validate_slots.py
@@ -6,6 +6,7 @@ from rasa_sdk import Tracker, FormValidationAction
 from rasa_sdk.executor import CollectingDispatcher
 from rasa_sdk.types import DomainDict
 import re
+from datetime import datetime
 
 class ValidateConsultaForm(FormValidationAction):
     def name(self) -> Text:
@@ -38,17 +39,12 @@ class ValidateConsultaForm(FormValidationAction):
         #    # validation failed, set this slot to None so that the
         #    # user will be asked for the slot again
         #    return {"cuisine": None}
+
+
 class ValidateCisamForm(FormValidationAction):
     def name(self) -> Text:
         return "validate_cisam_form"
-    
-    def check(email):
-      regex = '^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
-      if re.search(regex, email):
-        return "v"
-      else:
-        return "i"
-    
+
     # def set_slots_none(
     #         self,
     #         slot_value: Any,
@@ -60,7 +56,7 @@ class ValidateCisamForm(FormValidationAction):
     #     slot_name = tracker.get_slot("data_cenario_dois_menu")
 
     #     return {"cenario_dois_menu": slot_name, "user_nome_paciente": None, "user_nome_social": None, "user_telefone": None, "user_data_nasc": None,"user_sexo": None, "user_cpf": None, "user_nome_mae": None, "user_email": None, "user_end_cep": None, "user_end_rua": None, "user_end_numero": None, "user_end_complemento": None, "user_end_bairro": None, "user_end_cidade": None, "user_numero_sus": None, "user_certidao_nascimento": None}
-    
+
     def validate_user_lgpd(
             self,
             slot_value: Any,
@@ -70,11 +66,11 @@ class ValidateCisamForm(FormValidationAction):
     ) -> Dict[Text, Any]:
         """Validate user_lgpd"""
 
-        data_user_lgpd = slot_value
-        if data_user_lgpd == '1':
+        if slot_value == '1':
             dispatcher.utter_message(response="utter_user_lgpd_sim")
-            return {"user_lgpd": data_user_lgpd}
-        elif data_user_lgpd == '2':
+            dispatcher.utter_message(response="utter_cenario_um_menu")
+            return {"user_lgpd": slot_value}
+        elif slot_value == '2':
             dispatcher.utter_message(response="utter_user_lgpd_nao")
             return {"user_lgpd": None, "requested_slot": None}
         else:
@@ -90,13 +86,16 @@ class ValidateCisamForm(FormValidationAction):
     ) -> Dict[Text, Any]:
         """Validate cenario_um_menu"""
 
-        data_cenario_um_menu = slot_value
-        if data_cenario_um_menu == '1':
+        if slot_value == '#':
+            dispatcher.utter_message(response="utter_cenario_um_menu")
+            return {"cenario_um_menu": None, "user_lgpd": None}
+        elif slot_value == '1':
             dispatcher.utter_message(response="utter_cenario_um_menu_resp_um")
-            return {"cenario_um_menu": data_cenario_um_menu}
-        elif data_cenario_um_menu == '2':
+            dispatcher.utter_message(response="utter_user_logado_nome")
+            return {"cenario_um_menu": slot_value}
+        elif slot_value == '2':
             dispatcher.utter_message(response="utter_cenario_um_menu_resp_dois")
-            return {"requested_slot": None}
+            return {"cenario_um_menu": None, "user_lgpd": None, "requested_slot": None}
         else:
             dispatcher.utter_message(response="utter_cenario_um_menu_resp_errado")
             return {"cenario_um_menu": None}
@@ -110,12 +109,17 @@ class ValidateCisamForm(FormValidationAction):
     ) -> Dict[Text, Any]:
         """Validate user_logado_nome"""
 
-        data_user_logado_nome = slot_value
-        if data_user_logado_nome == '#':
+        if slot_value == '#':
+            dispatcher.utter_message(response="utter_cenario_um_menu")
             return {"cenario_um_menu": None, "user_logado_nome": None}
         else:
-            return {"user_logado_nome": data_user_logado_nome}
-        
+            if len(slot_value) >= 2 and not slot_value.isdigit():
+                dispatcher.utter_message(response="utter_user_prontuario")
+                return {"user_logado_nome": slot_value}
+            else:
+                dispatcher.utter_message(response="utter_user_logado_nome_invalido")
+                return {"user_logado_nome": None}
+
     def validate_user_prontuario(
             self,
             slot_value: Any,
@@ -125,11 +129,15 @@ class ValidateCisamForm(FormValidationAction):
     ) -> Dict[Text, Any]:
         """Validate user_prontuario"""
 
-        data_user_prontuario = slot_value
-        if data_user_prontuario == '#':
+        if slot_value == '#':
             return {"user_logado_nome": None, "user_prontuario": None}
         else:
-            return {"user_prontuario": data_user_prontuario}
+            if len(slot_value) >= 2 and slot_value.isdigit():
+                dispatcher.utter_message(response="utter_cenario_dois_menu")
+                return {"user_prontuario": slot_value}
+            else:
+                dispatcher.utter_message(response="utter_user_prontuario_invalido")
+                return {"user_prontuario": None}
 
     def validate_cenario_dois_menu(
             self,
@@ -140,24 +148,24 @@ class ValidateCisamForm(FormValidationAction):
     ) -> Dict[Text, Any]:
         """Validate cenario_dois_menu"""
 
-        data_cenario_dois_menu = slot_value
-        if data_cenario_dois_menu == '1':
+        if slot_value == '#':
+            return {"cenario_dois_menu": None, "user_prontuario": None}
+        elif slot_value == '1':
             dispatcher.utter_message(response="utter_cenario_dois_menu_resp_um")
-            return {"cenario_dois_menu": data_cenario_dois_menu}
-        elif data_cenario_dois_menu == '2':
+            return {"cenario_dois_menu": slot_value}
+        elif slot_value == '2':
             dispatcher.utter_message(response="utter_cenario_dois_menu_resp_dois")
-            return {"cenario_dois_menu": data_cenario_dois_menu}
-        elif data_cenario_dois_menu == '3':
+            return {"cenario_dois_menu": slot_value}
+        elif slot_value == '3':
             dispatcher.utter_message(response="utter_cenario_dois_menu_resp_tres")
-            return {"cenario_dois_menu": data_cenario_dois_menu}
-        elif data_cenario_dois_menu == '4':
+            return {"cenario_dois_menu": slot_value}
+        elif slot_value == '4':
             dispatcher.utter_message(response="utter_cenario_dois_menu_resp_quatro")
             dispatcher.utter_message(response="utter_user_nome_paciente")
-            return {"cenario_dois_menu": data_cenario_dois_menu}
+            return {"cenario_dois_menu": slot_value}
         else:
             dispatcher.utter_message(response="utter_cenario_dois_menu_resp_errado")
-            return {"cenario_dois_menu": None}  
-
+            return {"cenario_dois_menu": None}
 
     def validate_user_nome_paciente(
             self,
@@ -171,6 +179,7 @@ class ValidateCisamForm(FormValidationAction):
 
         # Retornar cenario_dois_menu
         if slot_value == '#':
+            dispatcher.utter_message(response="utter_cenario_dois_menu")
             return {"user_nome_paciente": None, "cenario_dois_menu": None}
         # Prosseguir para user_nome_paciente
         elif comparar == '4':
@@ -179,6 +188,7 @@ class ValidateCisamForm(FormValidationAction):
                 dispatcher.utter_message(response="utter_user_nome_paciente_invalido")
                 return {"user_nome_paciente": None}
             else:
+                dispatcher.utter_message(response="utter_user_nome_social")
                 return {"user_nome_paciente": slot_value}
         else:
             dispatcher.utter_message(response="utter_cenario_dois_resp_errada_voltar")
@@ -195,7 +205,12 @@ class ValidateCisamForm(FormValidationAction):
         if slot_value == '#':
             return {"user_nome_paciente": None, "user_nome_social": None}
         else:
-            return {"user_nome_social": slot_value}
+            if len(slot_value) >= 2 and not slot_value.isdigit():
+                dispatcher.utter_message(response="utter_user_telefone")
+                return {"user_nome_social": slot_value}
+            else:
+                dispatcher.utter_message(response="utter_user_nome_social_invalido")
+                return {"user_nome_social": None}
 
     def validate_user_telefone(
             self,
@@ -207,9 +222,14 @@ class ValidateCisamForm(FormValidationAction):
         """Validate user_telefone"""
 
         if slot_value == '#':
-            return {"user_nome_social": None}
+            return {"user_telefone": None, "user_nome_social": None}
         else:
-            return {"user_telefone": slot_value}
+            if UtilsForm.check_telefone(slot_value) == 'valido':
+                dispatcher.utter_message(response="utter_user_data_nasc")
+                return {"user_telefone": slot_value}
+            else:
+                dispatcher.utter_message(response="utter_user_telefone_invalido")
+                return {"user_telefone": None}
 
     def validate_user_data_nasc(
             self,
@@ -221,9 +241,14 @@ class ValidateCisamForm(FormValidationAction):
         """Validate user_data_nasc"""
 
         if slot_value == '#':
-            return {"user_telefone": None}
+            return {"user_data_nasc": None, "user_telefone": None}
         else:
-            return {"user_data_nasc": slot_value}
+            if UtilsForm.check_data_nasc(slot_value) == 'valido':
+                dispatcher.utter_message(response="utter_user_sexo")
+                return {"user_data_nasc": slot_value}
+            else:
+                dispatcher.utter_message(response="utter_user_data_nasc_invalido")
+                return {"user_data_nasc": None}
 
     def validate_user_sexo(
             self,
@@ -235,9 +260,14 @@ class ValidateCisamForm(FormValidationAction):
         """Validate user_sexo"""
 
         if slot_value == '#':
-            return {"user_data_nasc": None}
+            return {"user_sexo": None, "user_data_nasc": None}
         else:
-            return {"user_sexo": slot_value}
+            if slot_value.upper() == 'M' or slot_value.upper() == 'F':
+                dispatcher.utter_message(response="utter_user_cpf")
+                return {"user_sexo": slot_value}
+            else:
+                dispatcher.utter_message(response="utter_user_sexo_invalido")
+                return {"user_sexo": None}
 
     def validate_user_cpf(
             self,
@@ -249,9 +279,14 @@ class ValidateCisamForm(FormValidationAction):
         """Validate user_cpf"""
 
         if slot_value == '#':
-            return {"user_sexo": None}
+            return {"user_cpf": None, "user_sexo": None}
         else:
-            return {"user_cpf": slot_value}
+            if UtilsForm.check_cpf(slot_value) == "valido":
+                dispatcher.utter_message(response="utter_user_nome_mae")
+                return {"user_cpf": slot_value}
+            else:
+                dispatcher.utter_message(response="utter_user_cpf_invalido")
+                return {"user_cpf": None}
 
     def validate_user_nome_mae(
             self,
@@ -263,10 +298,14 @@ class ValidateCisamForm(FormValidationAction):
         """Validate user_nome_mae"""
 
         if slot_value == '#':
-            return {"user_cpf": None}
+            return {"user_nome_mae": None, "user_cpf": None}
         else:
-            dispatcher.utter_message(response="utter_user_email")
-            return {"user_nome_mae": slot_value}
+            if len(slot_value) >= 3 and not slot_value.isdigit():
+                dispatcher.utter_message(response="utter_user_email")
+                return {"user_nome_mae": slot_value}
+            else:
+                dispatcher.utter_message(response="utter_user_nome_mae_invalido")
+                return {"user_nome_mae": None}
 
     def validate_user_email(
             self,
@@ -276,15 +315,16 @@ class ValidateCisamForm(FormValidationAction):
             domain: DomainDict,
     ) -> Dict[Text, Any]:
         """Validate user_email"""
-        
+
         if slot_value == '#':
-            return {"user_nome_mae": None}
+            return {"user_email": None, "user_nome_mae": None}
         else:
-            if ValidateCisamForm.check(slot_value) == 'v':
+            if UtilsForm.check_email(slot_value) == 'valido':
+                dispatcher.utter_message(response="utter_user_end_cep")
                 return {"user_email": slot_value}
             else:
                 dispatcher.utter_message(response="utter_user_email_invalido")
-                return {"user_email":  None}
+                return {"user_email": None}
 
     def validate_user_end_cep(
             self,
@@ -296,9 +336,14 @@ class ValidateCisamForm(FormValidationAction):
         """Validate user_end_cep"""
 
         if slot_value == '#':
-            return {"user_email": None}
+            return {"user_end_cep": None, "user_email": None}
         else:
-            return {"user_end_cep": slot_value}
+            if UtilsForm.check_cep(slot_value) == 'valido':
+                dispatcher.utter_message(response="utter_user_end_rua")
+                return {"user_end_cep": slot_value}
+            else:
+                dispatcher.utter_message(response="utter_user_end_cep_invalido")
+                return {"user_end_cep": None}
 
     def validate_user_end_rua(
             self,
@@ -310,9 +355,14 @@ class ValidateCisamForm(FormValidationAction):
         """Validate user_end_rua"""
 
         if slot_value == '#':
-            return {"user_end_cep": None}
+            return {"user_end_cep": None, "user_end_rua": None}
         else:
-            return {"user_end_rua": slot_value}
+            if len(slot_value) >= 3 and not slot_value.isdigit():
+                dispatcher.utter_message(response="utter_user_end_numero")
+                return {"user_end_rua": slot_value}
+            else:
+                dispatcher.utter_message(response="utter_user_end_rua_invalido")
+                return {"user_end_rua": None}
 
     def validate_user_end_numero(
             self,
@@ -324,9 +374,14 @@ class ValidateCisamForm(FormValidationAction):
         """Validate user_end_numero"""
 
         if slot_value == '#':
-            return {"user_end_rua": None}
+            return {"user_end_rua": None, "user_end_numero": None}
         else:
-            return {"user_end_numero": slot_value}
+            if slot_value.isdigit():
+                dispatcher.utter_message(response="utter_user_end_complemento")
+                return {"user_end_numero": slot_value}
+            else:
+                dispatcher.utter_message(response="utter_user_end_numero_invalido")
+                return {"user_end_numero": None}
 
     def validate_user_end_complemento(
             self,
@@ -338,9 +393,14 @@ class ValidateCisamForm(FormValidationAction):
         """Validate user_end_complemento"""
 
         if slot_value == '#':
-            return {"user_end_numero": None}
+            return {"user_end_numero": None, "user_end_complemento": None}
         else:
-            return {"user_end_complemento": slot_value}
+            if len(slot_value) >= 3:
+                dispatcher.utter_message(response="utter_user_end_bairro")
+                return {"user_end_complemento": slot_value}
+            else:
+                dispatcher.utter_message(response="utter_user_end_complemento_invalido")
+                return {"user_end_complemento": None}
 
     def validate_user_end_bairro(
             self,
@@ -352,9 +412,14 @@ class ValidateCisamForm(FormValidationAction):
         """Validate user_end_bairro"""
 
         if slot_value == '#':
-            return {"user_end_complemento": None}
+            return {"user_end_bairro": None, "user_end_complemento": None}
         else:
-            return {"user_end_bairro": slot_value}
+            if len(slot_value) >= 3 and not slot_value.isdigit():
+                dispatcher.utter_message(response="utter_user_end_cidade")
+                return {"user_end_bairro": slot_value}
+            else:
+                dispatcher.utter_message(response="utter_user_end_bairro_invalido")
+                return {"user_end_bairro": None}
 
     def validate_user_end_cidade(
             self,
@@ -366,9 +431,33 @@ class ValidateCisamForm(FormValidationAction):
         """Validate user_end_cidade"""
 
         if slot_value == '#':
-            return {"user_end_bairro": None}
+            return {"user_end_cidade": None, "user_end_bairro": None}
         else:
-            return {"user_end_cidade": slot_value}
+            if len(slot_value) >= 3 and not slot_value.isdigit():
+                dispatcher.utter_message(response="utter_user_end_uf")
+                return {"user_end_cidade": slot_value}
+            else:
+                dispatcher.utter_message(response="utter_user_end_cidade_invalido")
+                return {"user_end_cidade": None}
+
+    def validate_user_end_uf(
+            self,
+            slot_value: Any,
+            dispatcher: CollectingDispatcher,
+            tracker: Tracker,
+            domain: DomainDict,
+    ) -> Dict[Text, Any]:
+        """Validate_user_end_uf"""
+
+        if slot_value == '#':
+            return {"user_end_uf": None, "user_end_cidade": None}
+        else:
+            if UtilsForm.check_uf(slot_value.upper()) == 'valido':
+                dispatcher.utter_message(response="utter_user_numero_sus")
+                return {"user_end_uf": slot_value}
+            else:
+                dispatcher.utter_message(response="utter_user_end_uf_invalido")
+                return {"user_end_uf": None}
 
     def validate_user_numero_sus(
             self,
@@ -380,9 +469,14 @@ class ValidateCisamForm(FormValidationAction):
         """Validate user_numero_sus"""
 
         if slot_value == '#':
-            return {"user_end_cidade": None}
+            return {"user_numero_sus": None, "user_end_uf": None}
         else:
-            return {"user_numero_sus": slot_value}
+            if len(slot_value) == 15 and slot_value.isdigit():
+                dispatcher.utter_message(response="utter_user_certidao_nascimento")
+                return {"user_numero_sus": slot_value}
+            else:
+                dispatcher.utter_message(response="utter_user_numero_sus_invalido")
+                return {"user_numero_sus": None}
 
     def validate_user_certidao_nascimento(
             self,
@@ -394,9 +488,14 @@ class ValidateCisamForm(FormValidationAction):
         """Validate user_certidao_nascimento"""
 
         if slot_value == '#':
-            return {"user_numero_sus": None}
+            return {"user_certidao_nascimento": None, "user_numero_sus": None}
         else:
-            return {"user_certidao_nascimento": slot_value}
+            if (len(slot_value) >= 3 and slot_value.isdigit()) or slot_value.upper() == 'NÃO' or slot_value.upper() == 'NAO':
+                dispatcher.utter_message(response="utter_user_certidao_casamento")
+                return {"user_certidao_nascimento": slot_value}
+            else:
+                dispatcher.utter_message(response="utter_user_certidao_nascimento_invalido")
+                return {"user_certidao_nascimento": None}
 
     def validate_user_certidao_casamento(
             self,
@@ -408,9 +507,66 @@ class ValidateCisamForm(FormValidationAction):
         """Validate user_certidao_casamento"""
 
         if slot_value == '#':
-            return {"user_certidao_nascimento": None}
+            return {"user_certidao_casamento": None, "user_certidao_nascimento": None}
         else:
-            dispatcher.utter_message(response="utter_despedir")
-            return {"user_certidao_casamento": slot_value}
+            if (len(slot_value) >= 3 and slot_value.isdigit()) or slot_value.upper() == 'NÃO' or slot_value.upper() == 'NAO':
+                dispatcher.utter_message(response="utter_despedir")
+                return {"user_certidao_casamento": slot_value}
+            else:
+                dispatcher.utter_message(response="utter_user_certidao_casamento_invalido")
+                return {"user_certidao_casamento": None}
+
+class UtilsForm:
+
+    def check_email(email):
+        regex = '^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
+        if re.search(regex, email):
+            return "valido"
+        else:
+            return "invalido"
+
+    def check_telefone(telefone):
+        regex = '^(?:[14689][1-9]|2[12478]|3[1234578]|5[1345]|7[134579])\-? ?(?:[2-8]|9[1-9])[0-9]{3}\-?[0-9]{4}$'
+        if re.search(regex, telefone):
+            return "valido"
+        else:
+            return "invalido"
+
+    def check_data_nasc(data_nasc):
+        formatos = ('%d.%m.%Y', '%d-%m-%Y', '%d/%m/%Y')
+
+        for formato in formatos:
+            try:
+                datetime.strptime(data_nasc, formato)
+                return "valido"
+            except ValueError:
+                pass
+        return "invalido"
+
+
+    def check_cpf(cpf):
+        regex = '^(\d{3})\.?(\d{3})\.?(\d{3})\-?(\d{2})$'
+        if re.search(regex, cpf):
+            return "valido"
+        else:
+            return "invalido"
+
+    def check_cep(cep):
+        regex = '(^[0-9]{5})-?([0-9]{3}$)'
+        if re.search(regex, cep):
+            return "valido"
+        else:
+            return "invalido"
+
+    def check_uf(uf):
+        estados = ("AC", "AL", "AP", "AM", "BA", "CE", "DF", "ES", "GO", "MA", "MT", "MS", "MG", "PA", "PB", "PR", "PE", "PI", "RJ", "RN", "RS", "RO", "RR", "SC", "SP", "SE", "TO")
+        for estado in estados:
+            if estado == uf:
+                return "valido"
+            else:
+                continue
+        return "invalido"
+
+
 
 

--- a/bot/domain.yml
+++ b/bot/domain.yml
@@ -179,6 +179,10 @@ slots:
     type: text
     initial_value: null
     influence_conversation: true
+  user_end_uf:
+    type: text
+    initial_value: null
+    influence_conversation: true
   user_numero_sus:
     type: text
     initial_value: null
@@ -191,7 +195,6 @@ slots:
     type: text
     initial_value: null
     influence_conversation: true
-
 
 forms:
   exemplo_forms:
@@ -268,6 +271,9 @@ forms:
       user_end_cidade:
       - type: from_text
         intent: null
+      user_end_uf:
+      - type: from_text
+        intent: null
       user_numero_sus:
       - type: from_text
         intent: null
@@ -287,7 +293,7 @@ responses:
   utter_ask_user_lgpd:
   - text: |
       Antes de iniciarmos, preciso saber se você concorda em fornecer seus dados pessoais ao NUTES CISAM de acordo com a Lei Geral de Proteção de dados (LGPD)  
-      Se sim, digite 1. 
+      Se sim, digite 1.
       Se não, digite 2.
 
   utter_user_lgpd_sim:
@@ -303,10 +309,10 @@ responses:
   - text: |
       Desculpe, informe o valor numérico 1 ou 2!
 
-  utter_ask_cenario_um_menu:
+  utter_cenario_um_menu:
   - text: |
       Você já possui prontuário no Cisam?
-
+         
       Se sim, digite 1.
       Se não, digite 2.
 
@@ -316,27 +322,35 @@ responses:
 
   utter_cenario_um_menu_resp_dois:
   - text: |
-      Entendi, você não possui prontuário! 
+      Entendi, você não possui prontuário!
       Para efetuar o seu cadastro e solicitar a TeleConsulta acesse o link: https://bit.ly/TeleConsultaCisam
 
   utter_cenario_um_menu_resp_errado:
   - text: |
       Desculpe, informe o valor numérico 1 ou 2!
 
-  utter_ask_user_logado_nome:
+  utter_user_logado_nome:
   - text: |
       Que bom! Nos informe o seu primeiro nome por favor.
       Exemplo: Maria
 
-  utter_ask_user_prontuario:
+  utter_user_logado_nome_invalido:
+  - text: |
+      Digite um nome válido.
+
+  utter_user_prontuario:
   - text: |
       Agora me informe o número do seu prontuario
 
-  utter_ask_cenario_dois_menu:
+  utter_user_prontuario_invalido:
+  - text: |
+      O prontuário digitado não é válido, vamos tentar novamente?
+
+  utter_cenario_dois_menu:
   - text: |
       Perfeito, Srª {user_logado_nome}!
       Agora, nos informe qual a opção que deseja.
-        
+          
       1: Saber mais sobre o que é NUTES.
       2: Saber mais sobre a Teleconsulta.
       3: Saber mais sobre o Planejamento Reprodutivo.
@@ -344,113 +358,201 @@ responses:
 
   utter_cenario_dois_menu_resp_um:
   - text: |
-        Caso deseje voltar para o diálogo anterior, digite: #.
+      Caso deseje voltar para o diálogo anterior, digite: #.
 
-        1: O que é o NUTES? Acesse o link https://www.youtube.com/watch?v=-a4P2d7rP7s
+      1: O que é o NUTES? Acesse o link https://www.youtube.com/watch?v=-a4P2d7rP7s
 
   utter_cenario_dois_menu_resp_dois:
   - text: |
-        Caso deseje voltar para o diálogo anterior, digite: #.
-        
-        2: Informações sobre a Teleconsulta. (VIDEO)  
+      Caso deseje voltar para o diálogo anterior, digite: #.
+
+      2: Informações sobre a Teleconsulta. (VIDEO)  
 
   utter_cenario_dois_menu_resp_tres:
   - text: |
-        Caso deseje voltar para o diálogo anterior, digite: #.
+      Caso deseje voltar para o diálogo anterior, digite: #.
 
-        3: Planejamento Reprodutivo. (VÍDEO)  
+      3: Planejamento Reprodutivo. (VÍDEO)  
 
   utter_cenario_dois_menu_resp_quatro:
   - text: |
-        Caso deseje voltar para o diálogo anterior, digite: #.
+      Caso deseje voltar para o diálogo anterior, digite: #.
 
-        4: Agendar Teleconsulta.  
+      4: Agendar Teleconsulta.
+
   utter_cenario_dois_menu_resp_errado:
   - text:
-        Desculpe, informe um valor numérico entre 1 e 4.
+      Desculpe, informe um valor numérico entre 1 e 4.
+
+  utter_cenario_dois_resp_errada_voltar:
+  - text: |
+      Caso deseje voltar para o diálogo anterior, digite: #.
+
   utter_user_nome_paciente:
   - text: |
       Ok, me informe o nome completo do(a) paciente.
+
   utter_user_nome_paciente_invalido:
-  - text:
-      Desculpe, não entendi! Acho que o nome que você está digitando possui um erro. Vamos tentar denovo? Por exemplo, Maria da Silva.
-  utter_ask_user_nome_social:
   - text: |
-      Nome social do(a) paciente (no caso de usar um nome diferente do seus documentos)
-      (Caso não possua, digite não)        
+      Desculpe, não entendi! Acho que o nome que você está digitando possui um erro. Vamos tentar de novo? Por exemplo, Maria da Silva.
 
-  utter_ask_user_telefone:
+  utter_user_nome_social:
   - text: |
-      Ótimo! Agora me informe o número do seu telefone ou celular;
-      Por exemplo: (81)3182-7758
+      Nome social do(a) paciente (no caso de usar um nome diferente do seus documentos).
+      (Caso não possua, digite não)
 
-  utter_ask_user_data_nasc:
+  utter_user_nome_social_invalido:
+  - text: |
+      Digite o nome social maior do que dois caracteres e que não contenha números.
+      (Caso não possua, digite não)
+
+  utter_user_telefone:
+  - text: |
+      Ótimo! Agora me informe o número do seu telefone ou celular.
+      Por exemplo: 81-3182-7758
+
+  utter_user_telefone_invalido:
+  - text: |
+      Ops! Número de telefone inválido, tente novamente! Por exemplo: 81-3182-7758     
+
+  utter_user_data_nasc:
   - text: |
       Agora me informe a sua data de nascimento.
-      Exemplo: 20/05/1980 
+      Exemplo: 20/05/1980
 
-  utter_ask_user_sexo:
+  utter_user_data_nasc_invalido:
+  - text: |
+      Acho que você digitou algo errado :(, tente novamente.
+      Exemplo: 20/05/1980
+
+  utter_user_sexo:
   - text: |
       Entendi, agora me informe o seu sexo.
-      Exemplo: F
+      Exemplo: F para feminino ou M para masculino.
 
-  utter_ask_user_cpf:
+  utter_user_sexo_invalido:
+  - text: |
+      Dado incorreto, favor inserir conforme exemplo: F para feminino ou M para masculino.      
+
+  utter_user_cpf:
   - text: |
       Ok, agora me informe o seu CPF.
       Por exemplo: 123.456.789-10
 
-  utter_ask_user_nome_mae:
+  utter_user_cpf_invalido:
+  - text: |
+      CPF digitado inválido, tente novamente.
+      Por exemplo: 123.456.789-10
+
+  utter_user_nome_mae:
   - text: |
       Me informe o nome completo da mãe do(a) paciente.
+
+  utter_user_nome_mae_invalido:
+  - text: |
+      Desculpe, não entendi! Acho que o nome que você está digitando possui um erro. Vamos tentar de novo? Por exemplo, Maria da Silva.
 
   utter_user_email:
   - text: |
       Certo. E qual o seu e-mail?
       Por exemplo: telessaude.cisam@upe.br
+
   utter_user_email_invalido:
   - text: |
       Por favor insira um e-mail válido.
 
-  utter_ask_user_end_cep:
+  utter_user_end_cep:
   - text: |
       Agora preciso que me informe o CEP.
       Por exemplo: 51380-450
 
-  utter_ask_user_end_rua:
+  utter_user_end_cep_invalido:
+  - text: |
+      CEP inválido, lembre-se que o o CEP é composto por 7 dígitos.
+      Por exemplo: 51380-450
+
+  utter_user_end_rua:
   - text: |
       Ok, entendi, agora preciso que me informe o nome da sua rua.
 
-  utter_ask_user_end_numero:
+  utter_user_end_rua_invalido:
+  - text: |
+      Desculpe, não entendi! Acho que o nome que você está digitando um nome de rua errado. Vamos tentar de novo? 
+
+  utter_user_end_numero:
   - text: |
       Entendi, agora preciso que vodê me informe o número da residência.
 
-  utter_ask_user_end_complemento:
+  utter_user_end_numero_invalido:
+  - text: |
+      Não entendi, podemos tentar novamente? Digite um número de residência válido.  
+
+  utter_user_end_complemento:
   - text: |
       Certo, agora me informe o complemento do seu endereço.
       (Caso não possua, digite não)
 
-  utter_ask_user_end_bairro:
+  utter_user_end_complemento_invalido:
+  - text: |
+      Complemento inválido, vamos tentar novamente.
+      (Caso não possua, digite não)
+
+  utter_user_end_bairro:
   - text: |
       Preciso que me informe o bairro onde você mora.
 
-  utter_ask_user_end_cidade:
+  utter_user_end_bairro_invalido:
   - text: |
-      Ok, me informe a cidade seguido do Estado.
-      Por exemplo: Recife-PE
+      Bairro digitado inválido, vamos tentar de novo.
 
-  utter_ask_user_numero_sus:
+  utter_user_end_cidade:
   - text: |
-      E qual o número do seu cartão do SUS?
-      Por exemplo: 9256875625159856
-  utter_ask_user_certidao_nascimento:
-  - text: |
-      Entendi, agora me informe a sua certidão de nascimento. 
-      (Caso não possua, digite não) 
+      Ok, me informe a cidade onde você mora.
+      Por exemplo: Recife
 
-  utter_ask_user_certidao_casamento:
+  utter_user_end_cidade_invalido:
   - text: |
-      Muito bom, agpra me diz qual o npumero da sua certidão de casamento. 
+      Cidade não é válida, vamos tentar novamente?
+
+  utter_user_end_uf:
+  - text: |
+      Agora preciso saber o Estado onde você mora.
+      Por exemplo: PE
+
+  utter_user_end_uf_invalido:
+  - text: |
+      UF inválido, vamos tentar novamente!
+      Por exemplo: PE
+
+  utter_user_numero_sus:
+  - text: |
+      E qual o número do seu cartão do SUS? Lembre-se, são 15 dígitos.
+      Por exemplo: 925687562515985
+
+  utter_user_numero_sus_invalido:
+  - text: |
+      Número informado inválido! Lembre-se, o número SUS é formado por 15 números.
+
+  utter_user_certidao_nascimento:
+  - text: |
+      Entendi, agora me informe a sua certidão de nascimento.
       (Caso não possua, digite não)
+
+  utter_user_certidao_nascimento_invalido:
+  - text: |
+      Não entendi, vamos tentar novamente? Digite a sua certidão de nascimento.
+      (Caso não possua, digite não)
+
+  utter_user_certidao_casamento:
+  - text: |
+      Muito bom, agpra me diz qual o número da sua certidão de casamento.
+      (Caso não possua, digite não)
+
+  utter_user_certidao_casamento_invalido:
+  - text: |
+      Não entendi, vamos tentar novamente? Digite a sua certidão de casamento.
+      (Caso não possua, digite não)
+
   utter_tipo_consulta_errado:
   - text: |
       Desculpe, informe um valor numérico entre 1 e 3!


### PR DESCRIPTION
## Descrição

- **validate_slots.py**
Add validador logado_nome
Add validador prontuario
Add validador nome_social
Add validador sexo
Add validador nome_mae
Add validador end_rua
Add validador end_numero
Add validador end_complemento
Add validador end_bairro
Add validador end_cidade
Add validador end_sus
Add validador certidao_nascimento
Add validador certidao_casamento
Add class UtilsForm
Movido o validador de e-mail para dentro da class UtilsForm 
Add na class UtilsForm validador telefone
Add na class UtilsForm validador data_nasc
Add na class UtilsForm validador cpf
Add na class UtilsForm validador cep
Add na class UtilsForm validador uf

- **domain.yml**
Add slot uf
Add utters uf
Adjust diálogos

## Resolve (Issues)

- **validate_slots.py**
Fixed retorno '#' que estavam preenchendo o slot atual.
