### PR TITLE
Add action para resetar slots do cisam_form

### DIFF
--- a/bot/actions/validate_slots.py
+++ b/bot/actions/validate_slots.py
@@ -6,56 +6,21 @@ from typing import Text, List, Any, Dict
 from rasa_sdk import Tracker, FormValidationAction, Action
 from rasa_sdk.executor import CollectingDispatcher
 from rasa_sdk.types import DomainDict
+from rasa_sdk.events import AllSlotsReset
 
 
-class ValidateConsultaForm(FormValidationAction):
-    def name(self) -> Text:
-        return "validate_consulta_form"
+class ActionResetAllSlots(Action):
 
-    def validate_tipo_consulta(
-            self,
-            slot_value: Any,
-            dispatcher: CollectingDispatcher,
-            tracker: Tracker,
-            domain: DomainDict,
-    ) -> Dict[Text, Any]:
-        """Validate tipo_consulta"""
+    def name(self):
+        return "action_reset_all_slots"
 
-        tipo_consulta = slot_value
-
-        if tipo_consulta.isdigit():
-            tipo_consulta = int(tipo_consulta)
-            if tipo_consulta > 0 and tipo_consulta <= 3:
-                # validation succeeded
-                return {"tipo_consulta": tipo_consulta}
-        # validation failed
-        dispatcher.utter_message(response="utter_tipo_consulta_errado")
-        return {"tipo_consulta": None}
-
-        # if slot_value.lower() in self.cuisine_db():
-        #    # validation succeeded, set the value of the "cuisine" slot to value
-        #    return {"cuisine": slot_value}
-        # else:
-        #    # validation failed, set this slot to None so that the
-        #    # user will be asked for the slot again
-        #    return {"cuisine": None}
+    def run(self, dispatcher, tracker, domain):
+        return [AllSlotsReset()]
 
 
 class ValidateCisamForm(FormValidationAction):
     def name(self) -> Text:
         return "validate_cisam_form"
-
-    # def set_slots_none(
-    #         self,
-    #         slot_value: Any,
-    #         dispatcher: CollectingDispatcher,
-    #         tracker: Tracker,
-    #         domain: DomainDict,
-    # ) -> Dict[Text, Any]:
-    #     """Zerar os Slots Cenário 2"""
-    #     slot_name = tracker.get_slot("data_cenario_dois_menu")
-
-    #     return {"cenario_dois_menu": slot_name, "user_nome_paciente": None, "user_nome_social": None, "user_telefone": None, "user_data_nasc": None,"user_sexo": None, "user_cpf": None, "user_nome_mae": None, "user_email": None, "user_end_cep": None, "user_end_rua": None, "user_end_numero": None, "user_end_complemento": None, "user_end_bairro": None, "user_end_cidade": None, "user_numero_sus": None, "user_certidao_nascimento": None}
 
     def validate_user_lgpd(
             self,
@@ -65,6 +30,8 @@ class ValidateCisamForm(FormValidationAction):
             domain: DomainDict,
     ) -> Dict[Text, Any]:
         """Validate user_lgpd"""
+
+        # listed_options = ['1', '2']
 
         if slot_value == '1':
             dispatcher.utter_message(response="utter_user_lgpd_sim")
@@ -139,386 +106,386 @@ class ValidateCisamForm(FormValidationAction):
                 dispatcher.utter_message(response="utter_user_prontuario_invalido")
                 return {"user_prontuario": None}
 
-    # def validate_cenario_dois_menu(
-    #         self,
-    #         slot_value: Any,
-    #         dispatcher: CollectingDispatcher,
-    #         tracker: Tracker,
-    #         domain: DomainDict,
-    # ) -> Dict[Text, Any]:
-    #     """Validate cenario_dois_menu"""
-    #
-    #     if slot_value == '#':
-    #         return {"cenario_dois_menu": None, "user_prontuario": None}
-    #     elif slot_value == '1':
-    #         dispatcher.utter_message(response="utter_cenario_dois_menu_resp_um")
-    #         return {"cenario_dois_menu": slot_value}
-    #     elif slot_value == '2':
-    #         dispatcher.utter_message(response="utter_cenario_dois_menu_resp_dois")
-    #         return {"cenario_dois_menu": slot_value}
-    #     elif slot_value == '3':
-    #         dispatcher.utter_message(response="utter_cenario_dois_menu_resp_tres")
-    #         return {"cenario_dois_menu": slot_value}
-    #     elif slot_value == '4':
-    #         dispatcher.utter_message(response="utter_cenario_dois_menu_resp_quatro")
-    #         dispatcher.utter_message(response="utter_user_nome_paciente")
-    #         return {"cenario_dois_menu": slot_value}
-    #     else:
-    #         dispatcher.utter_message(response="utter_cenario_dois_menu_resp_errado")
-    #         return {"cenario_dois_menu": None}
-    #
-    # def validate_user_nome_paciente(
-    #         self,
-    #         slot_value: Any,
-    #         dispatcher: CollectingDispatcher,
-    #         tracker: Tracker,
-    #         domain: DomainDict,
-    # ) -> Dict[Text, Any]:
-    #     """Validate user_nome_paciente"""
-    #     comparar = tracker.get_slot("cenario_dois_menu")
-    #
-    #     # Retornar cenario_dois_menu
-    #     if slot_value == '#':
-    #         dispatcher.utter_message(response="utter_cenario_dois_menu")
-    #         return {"user_nome_paciente": None, "cenario_dois_menu": None}
-    #     # Prosseguir para user_nome_paciente
-    #     elif comparar == '4':
-    #         # validador
-    #         if len(slot_value) <= 3 or slot_value.isdigit():
-    #             dispatcher.utter_message(response="utter_user_nome_paciente_invalido")
-    #             return {"user_nome_paciente": None}
-    #         else:
-    #             dispatcher.utter_message(response="utter_user_nome_social")
-    #             return {"user_nome_paciente": slot_value}
-    #     else:
-    #         dispatcher.utter_message(response="utter_cenario_dois_resp_errada_voltar")
-    #         return {"user_nome_paciente": None}
-    #
-    # def validate_user_nome_social(
-    #         self,
-    #         slot_value: Any,
-    #         dispatcher: CollectingDispatcher,
-    #         tracker: Tracker,
-    #         domain: DomainDict,
-    # ) -> Dict[Text, Any]:
-    #     """Validate user_nome_social"""
-    #     if slot_value == '#':
-    #         return {"user_nome_paciente": None, "user_nome_social": None}
-    #     else:
-    #         if len(slot_value) >= 2 and not slot_value.isdigit():
-    #             dispatcher.utter_message(response="utter_user_telefone")
-    #             return {"user_nome_social": slot_value}
-    #         else:
-    #             dispatcher.utter_message(response="utter_user_nome_social_invalido")
-    #             return {"user_nome_social": None}
-    #
-    # def validate_user_telefone(
-    #         self,
-    #         slot_value: Any,
-    #         dispatcher: CollectingDispatcher,
-    #         tracker: Tracker,
-    #         domain: DomainDict,
-    # ) -> Dict[Text, Any]:
-    #     """Validate user_telefone"""
-    #
-    #     if slot_value == '#':
-    #         return {"user_telefone": None, "user_nome_social": None}
-    #     else:
-    #         if UtilsForm.check_telefone(slot_value) == 'valido':
-    #             dispatcher.utter_message(response="utter_user_data_nasc")
-    #             return {"user_telefone": slot_value}
-    #         else:
-    #             dispatcher.utter_message(response="utter_user_telefone_invalido")
-    #             return {"user_telefone": None}
-    #
-    # def validate_user_data_nasc(
-    #         self,
-    #         slot_value: Any,
-    #         dispatcher: CollectingDispatcher,
-    #         tracker: Tracker,
-    #         domain: DomainDict,
-    # ) -> Dict[Text, Any]:
-    #     """Validate user_data_nasc"""
-    #
-    #     if slot_value == '#':
-    #         return {"user_data_nasc": None, "user_telefone": None}
-    #     else:
-    #         if UtilsForm.check_data_nasc(slot_value) == 'valido':
-    #             dispatcher.utter_message(response="utter_user_sexo")
-    #             return {"user_data_nasc": slot_value}
-    #         else:
-    #             dispatcher.utter_message(response="utter_user_data_nasc_invalido")
-    #             return {"user_data_nasc": None}
-    #
-    # def validate_user_sexo(
-    #         self,
-    #         slot_value: Any,
-    #         dispatcher: CollectingDispatcher,
-    #         tracker: Tracker,
-    #         domain: DomainDict,
-    # ) -> Dict[Text, Any]:
-    #     """Validate user_sexo"""
-    #
-    #     if slot_value == '#':
-    #         return {"user_sexo": None, "user_data_nasc": None}
-    #     else:
-    #         if slot_value.upper() == 'M' or slot_value.upper() == 'F':
-    #             dispatcher.utter_message(response="utter_user_cpf")
-    #             return {"user_sexo": slot_value}
-    #         else:
-    #             dispatcher.utter_message(response="utter_user_sexo_invalido")
-    #             return {"user_sexo": None}
-    #
-    # def validate_user_cpf(
-    #         self,
-    #         slot_value: Any,
-    #         dispatcher: CollectingDispatcher,
-    #         tracker: Tracker,
-    #         domain: DomainDict,
-    # ) -> Dict[Text, Any]:
-    #     """Validate user_cpf"""
-    #
-    #     if slot_value == '#':
-    #         return {"user_cpf": None, "user_sexo": None}
-    #     else:
-    #         if UtilsForm.check_cpf(slot_value) == "valido":
-    #             dispatcher.utter_message(response="utter_user_nome_mae")
-    #             return {"user_cpf": slot_value}
-    #         else:
-    #             dispatcher.utter_message(response="utter_user_cpf_invalido")
-    #             return {"user_cpf": None}
-    #
-    # def validate_user_nome_mae(
-    #         self,
-    #         slot_value: Any,
-    #         dispatcher: CollectingDispatcher,
-    #         tracker: Tracker,
-    #         domain: DomainDict,
-    # ) -> Dict[Text, Any]:
-    #     """Validate user_nome_mae"""
-    #
-    #     if slot_value == '#':
-    #         return {"user_nome_mae": None, "user_cpf": None}
-    #     else:
-    #         if len(slot_value) >= 3 and not slot_value.isdigit():
-    #             dispatcher.utter_message(response="utter_user_email")
-    #             return {"user_nome_mae": slot_value}
-    #         else:
-    #             dispatcher.utter_message(response="utter_user_nome_mae_invalido")
-    #             return {"user_nome_mae": None}
-    #
-    # def validate_user_email(
-    #         self,
-    #         slot_value: Any,
-    #         dispatcher: CollectingDispatcher,
-    #         tracker: Tracker,
-    #         domain: DomainDict,
-    # ) -> Dict[Text, Any]:
-    #     """Validate user_email"""
-    #
-    #     if slot_value == '#':
-    #         return {"user_email": None, "user_nome_mae": None}
-    #     else:
-    #         if UtilsForm.check_email(slot_value) == 'valido':
-    #             dispatcher.utter_message(response="utter_user_end_cep")
-    #             return {"user_email": slot_value}
-    #         else:
-    #             dispatcher.utter_message(response="utter_user_email_invalido")
-    #             return {"user_email": None}
-    #
-    # def validate_user_end_cep(
-    #         self,
-    #         slot_value: Any,
-    #         dispatcher: CollectingDispatcher,
-    #         tracker: Tracker,
-    #         domain: DomainDict,
-    # ) -> Dict[Text, Any]:
-    #     """Validate user_end_cep"""
-    #
-    #     if slot_value == '#':
-    #         return {"user_end_cep": None, "user_email": None}
-    #     else:
-    #         if UtilsForm.check_cep(slot_value) == 'valido':
-    #             dispatcher.utter_message(response="utter_user_end_rua")
-    #             return {"user_end_cep": slot_value}
-    #         else:
-    #             dispatcher.utter_message(response="utter_user_end_cep_invalido")
-    #             return {"user_end_cep": None}
-    #
-    # def validate_user_end_rua(
-    #         self,
-    #         slot_value: Any,
-    #         dispatcher: CollectingDispatcher,
-    #         tracker: Tracker,
-    #         domain: DomainDict,
-    # ) -> Dict[Text, Any]:
-    #     """Validate user_end_rua"""
-    #
-    #     if slot_value == '#':
-    #         return {"user_end_cep": None, "user_end_rua": None}
-    #     else:
-    #         if len(slot_value) >= 3 and not slot_value.isdigit():
-    #             dispatcher.utter_message(response="utter_user_end_numero")
-    #             return {"user_end_rua": slot_value}
-    #         else:
-    #             dispatcher.utter_message(response="utter_user_end_rua_invalido")
-    #             return {"user_end_rua": None}
-    #
-    # def validate_user_end_numero(
-    #         self,
-    #         slot_value: Any,
-    #         dispatcher: CollectingDispatcher,
-    #         tracker: Tracker,
-    #         domain: DomainDict,
-    # ) -> Dict[Text, Any]:
-    #     """Validate user_end_numero"""
-    #
-    #     if slot_value == '#':
-    #         return {"user_end_rua": None, "user_end_numero": None}
-    #     else:
-    #         if slot_value.isdigit():
-    #             dispatcher.utter_message(response="utter_user_end_complemento")
-    #             return {"user_end_numero": slot_value}
-    #         else:
-    #             dispatcher.utter_message(response="utter_user_end_numero_invalido")
-    #             return {"user_end_numero": None}
-    #
-    # def validate_user_end_complemento(
-    #         self,
-    #         slot_value: Any,
-    #         dispatcher: CollectingDispatcher,
-    #         tracker: Tracker,
-    #         domain: DomainDict,
-    # ) -> Dict[Text, Any]:
-    #     """Validate user_end_complemento"""
-    #
-    #     if slot_value == '#':
-    #         return {"user_end_numero": None, "user_end_complemento": None}
-    #     else:
-    #         if len(slot_value) >= 3:
-    #             dispatcher.utter_message(response="utter_user_end_bairro")
-    #             return {"user_end_complemento": slot_value}
-    #         else:
-    #             dispatcher.utter_message(response="utter_user_end_complemento_invalido")
-    #             return {"user_end_complemento": None}
-    #
-    # def validate_user_end_bairro(
-    #         self,
-    #         slot_value: Any,
-    #         dispatcher: CollectingDispatcher,
-    #         tracker: Tracker,
-    #         domain: DomainDict,
-    # ) -> Dict[Text, Any]:
-    #     """Validate user_end_bairro"""
-    #
-    #     if slot_value == '#':
-    #         return {"user_end_bairro": None, "user_end_complemento": None}
-    #     else:
-    #         if len(slot_value) >= 3 and not slot_value.isdigit():
-    #             dispatcher.utter_message(response="utter_user_end_cidade")
-    #             return {"user_end_bairro": slot_value}
-    #         else:
-    #             dispatcher.utter_message(response="utter_user_end_bairro_invalido")
-    #             return {"user_end_bairro": None}
-    #
-    # def validate_user_end_cidade(
-    #         self,
-    #         slot_value: Any,
-    #         dispatcher: CollectingDispatcher,
-    #         tracker: Tracker,
-    #         domain: DomainDict,
-    # ) -> Dict[Text, Any]:
-    #     """Validate user_end_cidade"""
-    #
-    #     if slot_value == '#':
-    #         return {"user_end_cidade": None, "user_end_bairro": None}
-    #     else:
-    #         if len(slot_value) >= 3 and not slot_value.isdigit():
-    #             dispatcher.utter_message(response="utter_user_end_uf")
-    #             return {"user_end_cidade": slot_value}
-    #         else:
-    #             dispatcher.utter_message(response="utter_user_end_cidade_invalido")
-    #             return {"user_end_cidade": None}
-    #
-    # def validate_user_end_uf(
-    #         self,
-    #         slot_value: Any,
-    #         dispatcher: CollectingDispatcher,
-    #         tracker: Tracker,
-    #         domain: DomainDict,
-    # ) -> Dict[Text, Any]:
-    #     """Validate_user_end_uf"""
-    #
-    #     if slot_value == '#':
-    #         return {"user_end_uf": None, "user_end_cidade": None}
-    #     else:
-    #         if UtilsForm.check_uf(slot_value.upper()) == 'valido':
-    #             dispatcher.utter_message(response="utter_user_numero_sus")
-    #             return {"user_end_uf": slot_value}
-    #         else:
-    #             dispatcher.utter_message(response="utter_user_end_uf_invalido")
-    #             return {"user_end_uf": None}
-    #
-    # def validate_user_numero_sus(
-    #         self,
-    #         slot_value: Any,
-    #         dispatcher: CollectingDispatcher,
-    #         tracker: Tracker,
-    #         domain: DomainDict,
-    # ) -> Dict[Text, Any]:
-    #     """Validate user_numero_sus"""
-    #
-    #     if slot_value == '#':
-    #         return {"user_numero_sus": None, "user_end_uf": None}
-    #     else:
-    #         if len(slot_value) == 15 and slot_value.isdigit():
-    #             dispatcher.utter_message(response="utter_user_certidao_nascimento")
-    #             return {"user_numero_sus": slot_value}
-    #         else:
-    #             dispatcher.utter_message(response="utter_user_numero_sus_invalido")
-    #             return {"user_numero_sus": None}
-    #
-    # def validate_user_certidao_nascimento(
-    #         self,
-    #         slot_value: Any,
-    #         dispatcher: CollectingDispatcher,
-    #         tracker: Tracker,
-    #         domain: DomainDict,
-    # ) -> Dict[Text, Any]:
-    #     """Validate user_certidao_nascimento"""
-    #
-    #     if slot_value == '#':
-    #         return {"user_certidao_nascimento": None, "user_numero_sus": None}
-    #     else:
-    #         if (
-    #                 len(slot_value) >= 3 and slot_value.isdigit()) or slot_value.upper() == 'NÃO' or slot_value.upper() == 'NAO':
-    #             dispatcher.utter_message(response="utter_user_certidao_casamento")
-    #             return {"user_certidao_nascimento": slot_value}
-    #         else:
-    #             dispatcher.utter_message(response="utter_user_certidao_nascimento_invalido")
-    #             return {"user_certidao_nascimento": None}
-    #
-    # def validate_user_certidao_casamento(
-    #         self,
-    #         slot_value: Any,
-    #         dispatcher: CollectingDispatcher,
-    #         tracker: Tracker,
-    #         domain: DomainDict,
-    # ) -> Dict[Text, Any]:
-    #     """Validate user_certidao_casamento"""
-    #
-    #     if slot_value == '#':
-    #         return {"user_certidao_casamento": None, "user_certidao_nascimento": None}
-    #     else:
-    #         if (
-    #                 len(slot_value) >= 3 and slot_value.isdigit()) or slot_value.upper() == 'NÃO' or slot_value.upper() == 'NAO':
-    #             dispatcher.utter_message(response="utter_despedir")
-    #             return {"user_certidao_casamento": slot_value}
-    #         else:
-    #             dispatcher.utter_message(response="utter_user_certidao_casamento_invalido")
-    #             return {"user_certidao_casamento": None}
-
-
+#     def validate_cenario_dois_menu(
+#             self,
+#             slot_value: Any,
+#             dispatcher: CollectingDispatcher,
+#             tracker: Tracker,
+#             domain: DomainDict,
+#     ) -> Dict[Text, Any]:
+#         """Validate cenario_dois_menu"""
+#
+#         if slot_value == '#':
+#             return {"cenario_dois_menu": None, "user_prontuario": None}
+#         elif slot_value == '1':
+#             dispatcher.utter_message(response="utter_cenario_dois_menu_resp_um")
+#             return {"cenario_dois_menu": slot_value}
+#         elif slot_value == '2':
+#             dispatcher.utter_message(response="utter_cenario_dois_menu_resp_dois")
+#             return {"cenario_dois_menu": slot_value}
+#         elif slot_value == '3':
+#             dispatcher.utter_message(response="utter_cenario_dois_menu_resp_tres")
+#             return {"cenario_dois_menu": slot_value}
+#         elif slot_value == '4':
+#             dispatcher.utter_message(response="utter_cenario_dois_menu_resp_quatro")
+#             dispatcher.utter_message(response="utter_user_nome_paciente")
+#             return {"cenario_dois_menu": slot_value}
+#         else:
+#             dispatcher.utter_message(response="utter_cenario_dois_menu_resp_errado")
+#             return {"cenario_dois_menu": None}
+#
+#     def validate_user_nome_paciente(
+#             self,
+#             slot_value: Any,
+#             dispatcher: CollectingDispatcher,
+#             tracker: Tracker,
+#             domain: DomainDict,
+#     ) -> Dict[Text, Any]:
+#         """Validate user_nome_paciente"""
+#         comparar = tracker.get_slot("cenario_dois_menu")
+#
+#         # Retornar cenario_dois_menu
+#         if slot_value == '#':
+#             dispatcher.utter_message(response="utter_cenario_dois_menu")
+#             return {"user_nome_paciente": None, "cenario_dois_menu": None}
+#         # Prosseguir para user_nome_paciente
+#         elif comparar == '4':
+#             # validador
+#             if len(slot_value) <= 3 or slot_value.isdigit():
+#                 dispatcher.utter_message(response="utter_user_nome_paciente_invalido")
+#                 return {"user_nome_paciente": None}
+#             else:
+#                 dispatcher.utter_message(response="utter_user_nome_social")
+#                 return {"user_nome_paciente": slot_value}
+#         else:
+#             dispatcher.utter_message(response="utter_cenario_dois_resp_errada_voltar")
+#             return {"user_nome_paciente": None}
+#
+#     def validate_user_nome_social(
+#             self,
+#             slot_value: Any,
+#             dispatcher: CollectingDispatcher,
+#             tracker: Tracker,
+#             domain: DomainDict,
+#     ) -> Dict[Text, Any]:
+#         """Validate user_nome_social"""
+#         if slot_value == '#':
+#             return {"user_nome_paciente": None, "user_nome_social": None}
+#         else:
+#             if len(slot_value) >= 2 and not slot_value.isdigit():
+#                 dispatcher.utter_message(response="utter_user_telefone")
+#                 return {"user_nome_social": slot_value}
+#             else:
+#                 dispatcher.utter_message(response="utter_user_nome_social_invalido")
+#                 return {"user_nome_social": None}
+#
+#     def validate_user_telefone(
+#             self,
+#             slot_value: Any,
+#             dispatcher: CollectingDispatcher,
+#             tracker: Tracker,
+#             domain: DomainDict,
+#     ) -> Dict[Text, Any]:
+#         """Validate user_telefone"""
+#
+#         if slot_value == '#':
+#             return {"user_telefone": None, "user_nome_social": None}
+#         else:
+#             if UtilsForm.check_telefone(slot_value) == 'valido':
+#                 dispatcher.utter_message(response="utter_user_data_nasc")
+#                 return {"user_telefone": slot_value}
+#             else:
+#                 dispatcher.utter_message(response="utter_user_telefone_invalido")
+#                 return {"user_telefone": None}
+#
+#     def validate_user_data_nasc(
+#             self,
+#             slot_value: Any,
+#             dispatcher: CollectingDispatcher,
+#             tracker: Tracker,
+#             domain: DomainDict,
+#     ) -> Dict[Text, Any]:
+#         """Validate user_data_nasc"""
+#
+#         if slot_value == '#':
+#             return {"user_data_nasc": None, "user_telefone": None}
+#         else:
+#             if UtilsForm.check_data_nasc(slot_value) == 'valido':
+#                 dispatcher.utter_message(response="utter_user_sexo")
+#                 return {"user_data_nasc": slot_value}
+#             else:
+#                 dispatcher.utter_message(response="utter_user_data_nasc_invalido")
+#                 return {"user_data_nasc": None}
+#
+#     def validate_user_sexo(
+#             self,
+#             slot_value: Any,
+#             dispatcher: CollectingDispatcher,
+#             tracker: Tracker,
+#             domain: DomainDict,
+#     ) -> Dict[Text, Any]:
+#         """Validate user_sexo"""
+#
+#         if slot_value == '#':
+#             return {"user_sexo": None, "user_data_nasc": None}
+#         else:
+#             if slot_value.upper() == 'M' or slot_value.upper() == 'F':
+#                 dispatcher.utter_message(response="utter_user_cpf")
+#                 return {"user_sexo": slot_value}
+#             else:
+#                 dispatcher.utter_message(response="utter_user_sexo_invalido")
+#                 return {"user_sexo": None}
+#
+#     def validate_user_cpf(
+#             self,
+#             slot_value: Any,
+#             dispatcher: CollectingDispatcher,
+#             tracker: Tracker,
+#             domain: DomainDict,
+#     ) -> Dict[Text, Any]:
+#         """Validate user_cpf"""
+#
+#         if slot_value == '#':
+#             return {"user_cpf": None, "user_sexo": None}
+#         else:
+#             if UtilsForm.check_cpf(slot_value) == "valido":
+#                 dispatcher.utter_message(response="utter_user_nome_mae")
+#                 return {"user_cpf": slot_value}
+#             else:
+#                 dispatcher.utter_message(response="utter_user_cpf_invalido")
+#                 return {"user_cpf": None}
+#
+#     def validate_user_nome_mae(
+#             self,
+#             slot_value: Any,
+#             dispatcher: CollectingDispatcher,
+#             tracker: Tracker,
+#             domain: DomainDict,
+#     ) -> Dict[Text, Any]:
+#         """Validate user_nome_mae"""
+#
+#         if slot_value == '#':
+#             return {"user_nome_mae": None, "user_cpf": None}
+#         else:
+#             if len(slot_value) >= 3 and not slot_value.isdigit():
+#                 dispatcher.utter_message(response="utter_user_email")
+#                 return {"user_nome_mae": slot_value}
+#             else:
+#                 dispatcher.utter_message(response="utter_user_nome_mae_invalido")
+#                 return {"user_nome_mae": None}
+#
+#     def validate_user_email(
+#             self,
+#             slot_value: Any,
+#             dispatcher: CollectingDispatcher,
+#             tracker: Tracker,
+#             domain: DomainDict,
+#     ) -> Dict[Text, Any]:
+#         """Validate user_email"""
+#
+#         if slot_value == '#':
+#             return {"user_email": None, "user_nome_mae": None}
+#         else:
+#             if UtilsForm.check_email(slot_value) == 'valido':
+#                 dispatcher.utter_message(response="utter_user_end_cep")
+#                 return {"user_email": slot_value}
+#             else:
+#                 dispatcher.utter_message(response="utter_user_email_invalido")
+#                 return {"user_email": None}
+#
+#     def validate_user_end_cep(
+#             self,
+#             slot_value: Any,
+#             dispatcher: CollectingDispatcher,
+#             tracker: Tracker,
+#             domain: DomainDict,
+#     ) -> Dict[Text, Any]:
+#         """Validate user_end_cep"""
+#
+#         if slot_value == '#':
+#             return {"user_end_cep": None, "user_email": None}
+#         else:
+#             if UtilsForm.check_cep(slot_value) == 'valido':
+#                 dispatcher.utter_message(response="utter_user_end_rua")
+#                 return {"user_end_cep": slot_value}
+#             else:
+#                 dispatcher.utter_message(response="utter_user_end_cep_invalido")
+#                 return {"user_end_cep": None}
+#
+#     def validate_user_end_rua(
+#             self,
+#             slot_value: Any,
+#             dispatcher: CollectingDispatcher,
+#             tracker: Tracker,
+#             domain: DomainDict,
+#     ) -> Dict[Text, Any]:
+#         """Validate user_end_rua"""
+#
+#         if slot_value == '#':
+#             return {"user_end_cep": None, "user_end_rua": None}
+#         else:
+#             if len(slot_value) >= 3 and not slot_value.isdigit():
+#                 dispatcher.utter_message(response="utter_user_end_numero")
+#                 return {"user_end_rua": slot_value}
+#             else:
+#                 dispatcher.utter_message(response="utter_user_end_rua_invalido")
+#                 return {"user_end_rua": None}
+#
+#     def validate_user_end_numero(
+#             self,
+#             slot_value: Any,
+#             dispatcher: CollectingDispatcher,
+#             tracker: Tracker,
+#             domain: DomainDict,
+#     ) -> Dict[Text, Any]:
+#         """Validate user_end_numero"""
+#
+#         if slot_value == '#':
+#             return {"user_end_rua": None, "user_end_numero": None}
+#         else:
+#             if slot_value.isdigit():
+#                 dispatcher.utter_message(response="utter_user_end_complemento")
+#                 return {"user_end_numero": slot_value}
+#             else:
+#                 dispatcher.utter_message(response="utter_user_end_numero_invalido")
+#                 return {"user_end_numero": None}
+#
+#     def validate_user_end_complemento(
+#             self,
+#             slot_value: Any,
+#             dispatcher: CollectingDispatcher,
+#             tracker: Tracker,
+#             domain: DomainDict,
+#     ) -> Dict[Text, Any]:
+#         """Validate user_end_complemento"""
+#
+#         if slot_value == '#':
+#             return {"user_end_numero": None, "user_end_complemento": None}
+#         else:
+#             if len(slot_value) >= 3:
+#                 dispatcher.utter_message(response="utter_user_end_bairro")
+#                 return {"user_end_complemento": slot_value}
+#             else:
+#                 dispatcher.utter_message(response="utter_user_end_complemento_invalido")
+#                 return {"user_end_complemento": None}
+#
+#     def validate_user_end_bairro(
+#             self,
+#             slot_value: Any,
+#             dispatcher: CollectingDispatcher,
+#             tracker: Tracker,
+#             domain: DomainDict,
+#     ) -> Dict[Text, Any]:
+#         """Validate user_end_bairro"""
+#
+#         if slot_value == '#':
+#             return {"user_end_bairro": None, "user_end_complemento": None}
+#         else:
+#             if len(slot_value) >= 3 and not slot_value.isdigit():
+#                 dispatcher.utter_message(response="utter_user_end_cidade")
+#                 return {"user_end_bairro": slot_value}
+#             else:
+#                 dispatcher.utter_message(response="utter_user_end_bairro_invalido")
+#                 return {"user_end_bairro": None}
+#
+#     def validate_user_end_cidade(
+#             self,
+#             slot_value: Any,
+#             dispatcher: CollectingDispatcher,
+#             tracker: Tracker,
+#             domain: DomainDict,
+#     ) -> Dict[Text, Any]:
+#         """Validate user_end_cidade"""
+#
+#         if slot_value == '#':
+#             return {"user_end_cidade": None, "user_end_bairro": None}
+#         else:
+#             if len(slot_value) >= 3 and not slot_value.isdigit():
+#                 dispatcher.utter_message(response="utter_user_end_uf")
+#                 return {"user_end_cidade": slot_value}
+#             else:
+#                 dispatcher.utter_message(response="utter_user_end_cidade_invalido")
+#                 return {"user_end_cidade": None}
+#
+#     def validate_user_end_uf(
+#             self,
+#             slot_value: Any,
+#             dispatcher: CollectingDispatcher,
+#             tracker: Tracker,
+#             domain: DomainDict,
+#     ) -> Dict[Text, Any]:
+#         """Validate_user_end_uf"""
+#
+#         if slot_value == '#':
+#             return {"user_end_uf": None, "user_end_cidade": None}
+#         else:
+#             if UtilsForm.check_uf(slot_value.upper()) == 'valido':
+#                 dispatcher.utter_message(response="utter_user_numero_sus")
+#                 return {"user_end_uf": slot_value}
+#             else:
+#                 dispatcher.utter_message(response="utter_user_end_uf_invalido")
+#                 return {"user_end_uf": None}
+#
+#     def validate_user_numero_sus(
+#             self,
+#             slot_value: Any,
+#             dispatcher: CollectingDispatcher,
+#             tracker: Tracker,
+#             domain: DomainDict,
+#     ) -> Dict[Text, Any]:
+#         """Validate user_numero_sus"""
+#
+#         if slot_value == '#':
+#             return {"user_numero_sus": None, "user_end_uf": None}
+#         else:
+#             if len(slot_value) == 15 and slot_value.isdigit():
+#                 dispatcher.utter_message(response="utter_user_certidao_nascimento")
+#                 return {"user_numero_sus": slot_value}
+#             else:
+#                 dispatcher.utter_message(response="utter_user_numero_sus_invalido")
+#                 return {"user_numero_sus": None}
+#
+#     def validate_user_certidao_nascimento(
+#             self,
+#             slot_value: Any,
+#             dispatcher: CollectingDispatcher,
+#             tracker: Tracker,
+#             domain: DomainDict,
+#     ) -> Dict[Text, Any]:
+#         """Validate user_certidao_nascimento"""
+#
+#         if slot_value == '#':
+#             return {"user_certidao_nascimento": None, "user_numero_sus": None}
+#         else:
+#             if (
+#                     len(slot_value) >= 3 and slot_value.isdigit()) or slot_value.upper() == 'NÃO' or slot_value.upper() == 'NAO':
+#                 dispatcher.utter_message(response="utter_user_certidao_casamento")
+#                 return {"user_certidao_nascimento": slot_value}
+#             else:
+#                 dispatcher.utter_message(response="utter_user_certidao_nascimento_invalido")
+#                 return {"user_certidao_nascimento": None}
+#
+#     def validate_user_certidao_casamento(
+#             self,
+#             slot_value: Any,
+#             dispatcher: CollectingDispatcher,
+#             tracker: Tracker,
+#             domain: DomainDict,
+#     ) -> Dict[Text, Any]:
+#         """Validate user_certidao_casamento"""
+#
+#         if slot_value == '#':
+#             return {"user_certidao_casamento": None, "user_certidao_nascimento": None}
+#         else:
+#             if (
+#                     len(slot_value) >= 3 and slot_value.isdigit()) or slot_value.upper() == 'NÃO' or slot_value.upper() == 'NAO':
+#                 dispatcher.utter_message(response="utter_despedir")
+#                 return {"user_certidao_casamento": slot_value}
+#             else:
+#                 dispatcher.utter_message(response="utter_user_certidao_casamento_invalido")
+#                 return {"user_certidao_casamento": None}
+#
+#
 # class UtilsForm:
 #
 #     def check_email(email):
@@ -570,8 +537,8 @@ class ValidateCisamForm(FormValidationAction):
 #             else:
 #                 continue
 #         return "invalido"
-
-
+#
+#
 # def DataUpdate(a, b, c, d, e, f, g, h, i, j, la, m, n, o, p, q, r, s, t, u):
 #     mydb = mysql.connector.connect(
 #         host="127.0.0.1",
@@ -591,7 +558,7 @@ class ValidateCisamForm(FormValidationAction):
 #     mycursor.execute(sql)
 #     mydb.commit()
 #
-
+#
 # class ActionSubmit(Action):
 #
 #     def name(self) -> Text:
@@ -624,38 +591,6 @@ class ValidateCisamForm(FormValidationAction):
 #         DataUpdate(a, b, c, d, e, f, g, h, i, j, la, m, n, o, p, q, r, s, t, u)
 #         return []
 #
-#
-# def DataUpdate(a, b):
-#
-#     mydb = mysql.connector.connect(
-#         host='mysqldb',
-#         user="root",
-#         password="root",
-#         database="Cisam"
-#     )
-#
-#     mycursor = mydb.cursor()
-#
-#     sql = 'INSERT INTO UserCisam (user_lgpd, user_prontuario) VALUES ("{0}","{1}");'.format(a, b)
-#     mycursor.execute(sql)
-#     mydb.commit()
-#     mydb.close()
-#
-#
-# class ActionSubmit(Action):
-#
-#     def name(self) -> Text:
-#         return "action_submit"
-#
-#     def run(self, dispatcher: CollectingDispatcher,
-#             tracker: Tracker,
-#             domain: Dict[Text, Any]) -> List[Dict[Text, Any]]:
-#         dispatcher.utter_message(text="Enviando para o DB")
-#         a = tracker.get_slot("user_lgpd")
-#         b = tracker.get_slot("user_prontuario")
-#
-#         DataUpdate(a, b)
-#         return []
 
 def DataUpdate(a, b):
 

--- a/bot/data/rules.yml
+++ b/bot/data/rules.yml
@@ -1,34 +1,12 @@
 version: "2.0"
 rules:
-  # response selectors
-- rule: explica
-  steps:
-  - intent: explica
-  - action: utter_explica
-  # forms
+
+# Fallback form
 
 - rule: Pedir para reformular a mensagem caso NLU não entenda
   steps:
   - intent: nlu_fallback
   - action: utter_nao_nlu
-
-- rule: Ativa formulário
-  steps:
-  - intent: exemplo_forms
-  - action: utter_exemplo_forms
-  - action: exemplo_forms
-  - active_loop: exemplo_forms
-
-- rule: Envia formulário
-  condition:
-  - active_loop: exemplo_forms
-  steps:
-  - action: exemplo_forms
-  - active_loop: null
-  - slot_was_set:
-    - requested_slot: null
-  - action: utter_submit_exemplo_forms
-  - action: utter_slots_exemplo_forms
 
 # Cisam form
 - rule: Ativa formulário Cisam
@@ -47,4 +25,5 @@ rules:
   - slot_was_set:
     - requested_slot: null
   - action: action_submit
+  - action: action_reset_all_slots
 

--- a/bot/data/stories.yml
+++ b/bot/data/stories.yml
@@ -97,8 +97,4 @@ stories:
   - intent: exemplo_acao
     entities:
       - acao
-  - action: action_exemplo
-- story: cadastro
-  steps:
-  - intent: cadastro
-  - action: utter_cadastro
+#  - action: action_exemplo

--- a/bot/domain.yml
+++ b/bot/domain.yml
@@ -1,7 +1,6 @@
 version: '2.0'
 
 intents:
-- consulta_form
 - cumprimentar:
     use_entities: true
 - relacionamento:
@@ -54,8 +53,6 @@ intents:
     use_entities: true
 - exemplo_forms:
     use_entities: true
-- cadastro:
-    use_entities: true
 - explica:
     use_entities: true
 - nlu_fallback:
@@ -86,23 +83,8 @@ entities:
 - storie
 - acao
 - forms
-- cadastro
 
 slots:
-  nome:
-    type: text
-    initial_value: null
-    auto_fill: false
-    influence_conversation: false
-  idade:
-    type: text
-    initial_value: null
-    auto_fill: false
-    influence_conversation: false
-  tipo_consulta:
-    type: text
-    initial_value: null
-    influence_conversation: true
   user_lgpd:
     type: text
     initial_value: null
@@ -197,21 +179,6 @@ slots:
 #    influence_conversation: true
 
 forms:
-  exemplo_forms:
-    required_slots:
-      idade:
-      - entity: idade
-        intent: informar
-        type: from_entity
-      nome:
-      - entity: nome
-        intent: informar
-        type: from_entity
-  consulta_form:
-    required_slots:
-      tipo_consulta:
-      - type: from_text
-        intent: null
   cisam_form:
     required_slots:
       user_lgpd:
@@ -285,17 +252,26 @@ forms:
 #        intent: null
 
 actions:
-- action_exemplo
-- validate_consulta_form
 - validate_cisam_form
 - action_submit
+- action_reset_all_slots
 
 responses:
-  utter_ask_user_lgpd:
+  utter_cumprimentar:
   - text: |
-      Antes de iniciarmos, preciso saber se você concorda em fornecer seus dados pessoais ao NUTES CISAM de acordo com a Lei Geral de Proteção de dados (LGPD)  
-      Se sim, digite 1.
-      Se não, digite 2.
+      Olá! Sou a Clau a atendente virtual do Cisam.
+      Será um prazer ajudá-la(o). Para prosseguir você deverá digitar as opções apresentadas na conversa.
+        
+      Caso deseje voltar para o diálogo anterior, digite: #.
+
+  utter_ask_user_lgpd:
+  - text: "Antes de começar, preciso saber se você concorda em fornecer seus dados pessoais ao NUTES CISAM de acordo com a Lei Geral de Proteção de dados (LGPD)"
+#    button_type: vertical
+    buttons:
+      - title: "Sim, concordo."
+        payload: '1'
+      - title: "Não concordo."
+        payload: '2'
 
   utter_user_lgpd_sim:
   - text: |
@@ -311,11 +287,10 @@ responses:
       Desculpe, informe o valor numérico 1 ou 2!
 
   utter_cenario_um_menu:
-  - text: |
-      Você já possui prontuário no Cisam?
-         
-      Se sim, digite 1.
-      Se não, digite 2.
+  - text:
+      "Você já possui prontuário no Cisam?  \n      
+      Se sim, digite 1.  \n
+      Se não, digite 2."
 
   utter_cenario_um_menu_resp_um:
   - text: |
@@ -341,45 +316,39 @@ responses:
 
   utter_user_prontuario:
   - text: |
-      Agora me informe o número do seu prontuario
+      Agora me informe o número do seu prontuário
 
   utter_user_prontuario_invalido:
   - text: |
       O prontuário digitado não é válido, vamos tentar novamente?
 
   utter_cenario_dois_menu:
-  - text: |
-      Perfeito, Srª {user_logado_nome}!
-      Agora, nos informe qual a opção que deseja.
-          
-      1: Saber mais sobre o que é NUTES.
-      2: Saber mais sobre a Teleconsulta.
-      3: Saber mais sobre o Planejamento Reprodutivo.
-      4: Agendar Teleconsulta para Planejamento Reprodutivo.
+  - text: "Perfeito, Srª {user_logado_nome}!  \n  
+      Agora, nos informe qual a opção que deseja.  \n  
+      1. Saber mais sobre o que é NUTES.  \n  
+      2. Saber mais sobre a Teleconsulta.  \n  
+      3. Saber mais sobre o Planejamento Reprodutivo.  \n 
+      4. Agendar Teleconsulta para Planejamento Reprodutivo."
 
   utter_cenario_dois_menu_resp_um:
-  - text: |
-      Caso deseje voltar para o diálogo anterior, digite: #.
-
-      1: O que é o NUTES? Acesse o link https://www.youtube.com/watch?v=-a4P2d7rP7s
+  - text:
+      "Caso deseje voltar para o diálogo anterior, digite: #.  \n
+      1. O que é o NUTES? Acesse o link https://www.youtube.com/watch?v=-a4P2d7rP7s"
 
   utter_cenario_dois_menu_resp_dois:
-  - text: |
-      Caso deseje voltar para o diálogo anterior, digite: #.
-
-      2: Informações sobre a Teleconsulta. (VIDEO)  
+  - text:
+      "Caso deseje voltar para o diálogo anterior, digite: #.  \n
+      2. Informações sobre a Teleconsulta. (VIDEO)"
 
   utter_cenario_dois_menu_resp_tres:
-  - text: |
-      Caso deseje voltar para o diálogo anterior, digite: #.
-
-      3: Planejamento Reprodutivo. (VÍDEO)  
+  - text:
+      "Caso deseje voltar para o diálogo anterior, digite: #.  \n
+      3. Planejamento Reprodutivo. (VÍDEO)"
 
   utter_cenario_dois_menu_resp_quatro:
-  - text: |
-      Caso deseje voltar para o diálogo anterior, digite: #.
-
-      4: Agendar Teleconsulta.
+  - text:
+      "Caso deseje voltar para o diálogo anterior, digite: #.  \n
+      4. Agendar Teleconsulta."
 
   utter_cenario_dois_menu_resp_errado:
   - text:
@@ -410,7 +379,7 @@ responses:
   utter_user_telefone:
   - text: |
       Ótimo! Agora me informe o número do seu telefone ou celular.
-      Por exemplo: 81-3182-7758
+      Exemplo: 81-3182-7758
 
   utter_user_telefone_invalido:
   - text: |
@@ -456,7 +425,7 @@ responses:
   utter_user_email:
   - text: |
       Certo. E qual o seu e-mail?
-      Por exemplo: telessaude.cisam@upe.br
+      Exemplo: telessaude.cisam@upe.br
 
   utter_user_email_invalido:
   - text: |
@@ -465,16 +434,16 @@ responses:
   utter_user_end_cep:
   - text: |
       Agora preciso que me informe o CEP.
-      Por exemplo: 51380-450
+      Exemplo: 51380-450
 
   utter_user_end_cep_invalido:
   - text: |
       CEP inválido, lembre-se que o o CEP é composto por 7 dígitos.
-      Por exemplo: 51380-450
+      Exemplo: 51380-450
 
   utter_user_end_rua:
   - text: |
-      Ok, entendi, agora preciso que me informe o nome da sua rua.
+      Ok, entendi, agora preciso que me informe o nome da rua onde você mora.
 
   utter_user_end_rua_invalido:
   - text: |
@@ -482,7 +451,7 @@ responses:
 
   utter_user_end_numero:
   - text: |
-      Entendi, agora preciso que vodê me informe o número da residência.
+      Entendi, agora preciso que você me informe o número da residência.
 
   utter_user_end_numero_invalido:
   - text: |
@@ -546,7 +515,7 @@ responses:
 
   utter_user_certidao_casamento:
   - text: |
-      Muito bom, agpra me diz qual o número da sua certidão de casamento.
+      Muito bom, agora me diz qual o número da sua certidão de casamento.
       (Caso não possua, digite não)
 
   utter_user_certidao_casamento_invalido:
@@ -554,53 +523,6 @@ responses:
       Não entendi, vamos tentar novamente? Digite a sua certidão de casamento.
       (Caso não possua, digite não)
 
-  utter_tipo_consulta_errado:
-  - text: |
-      Desculpe, informe um valor numérico entre 1 e 3!
-  
-  utter_voltar_resp_errada:
-  - text:
-      Digite "#" para voltar ou "sair" para encerrar.
-
-  utter_consulta_form:
-  - text: |
-      Ok, vou marcar uma consulta pra você! 
-
-  utter_ask_tipo_consulta:
-  - text: |
-      Qual consulta você quer? 
-
-       1: Genicologia 
-       2: Genicologia
-       3: Genicologia
-
-  utter_consulta_slots:
-  - text: |
-      A consulta que você quer é a de número {tipo_consulta}!
-
-  utter_cadastro:
-  - text: |
-      Ahh! Entendi, você quer se cadastrar! Abaixo seguem as informações para efetuar o seu cadastro.
-      Acesse o link para solicitar a Tele Consulta: https://bit.ly/TeleConsultraCisam
-  utter_fallback:
-  - text: |
-      Desculpe, ainda não sei falar sobre isso ou talvez não consegui entender direito
-      Você pode perguntar de novo de outro jeito?
-  - text: |
-      Hummmm... Não sei se entendi. Pode escrever de outra forma?
-  - text: |
-      Acho que não te entendi, você pode me perguntar de novo usando outras palavras?
-  - text: |
-      Vamos tentar mais uma vez? Eu não consegui te entender direito, me pergunta de outro jeito?
-  utter_elogios:
-  - text: |
-      Obrigada! É sempre bom dar e receber elogios :P
-  utter_cumprimentar:
-  - text: |
-      Olá! Sou a Clau a atendente virtual do Cisam.
-      Será um prazer ajudá-la(o). Para prosseguir você deverá digitar as opções apresentadas na conversa.
-      
-      Caso deseje voltar para o diáglogo anterior, digite: #.
   utter_despedir:
   - text: |
       Foi um prazer conversar com você!
@@ -614,6 +536,24 @@ responses:
       Foi um prazer te ajudar!
       Quando surgir alguma dúvida, volte aqui!
       O CISAM agradece o seu contato! Até mais!
+
+  utter_voltar_resp_errada:
+  - text:
+      Digite "#" para voltar ou "sair" para encerrar.
+
+  utter_fallback:
+  - text: |
+      Desculpe, ainda não sei falar sobre isso ou talvez não consegui entender direito
+      Você pode perguntar de novo de outro jeito?
+  - text: |
+      Hummmm... Não sei se entendi. Pode escrever de outra forma?
+  - text: |
+      Acho que não te entendi, você pode me perguntar de novo usando outras palavras?
+  - text: |
+      Vamos tentar mais uma vez? Eu não consegui te entender direito, me pergunta de outro jeito?
+  utter_elogios:
+  - text: |
+      Obrigada! É sempre bom dar e receber elogios :P
   utter_tudo_bem:
   - text: |
       Tudo bem, obrigada! Em que posso te ajudar?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     depends_on:
       - actions
       - mysqldb
+      - backup-mysqldb
     networks:
       - rasa-net
   # ================================= Actions =================================
@@ -59,16 +60,35 @@ services:
         - rasa-net
 
   # ============================ Database =================================
-  # Specific Rasa bot integrated with Telegram.
   mysqldb:
       image: mysql
       container_name: mysqldb
       restart: always
       environment:
         - MYSQL_ROOT_PASSWORD=root
+      volumes:
+        - mysql-volume:/var/lib/mysql:rw
+        - ./mysql:/docker-entrypoint-initdb.d
       ports:
         - 3306:3306
-        - 3307:3307
+      networks:
+        - rasa-net
+
+  # ============================ Backup =================================
+  backup-mysqldb:
+      image: databack/mysql-backup
+      container_name: Backup
+      restart: always
+      volumes:
+        - ./backups:/db:rw #./backups é a pasta local que vai receber o .tgz e /db é a pasta interna do container Backup
+      environment:
+        - DB_DUMP_TARGET=/db #/db é a pasta interna do container Backup
+        - DB_USER=root
+        - DB_PASS=root
+        - DB_DUMP_FREQ=3 #Backup a cada 3min
+        - DB_DUMP_BEGIN=+1 #Bakckup se inicia a partir do 1min do container up
+        - DB_SERVER=mysqldb #Nome do service docker-compose que será acessado
+        - DB_NAMES=Cisam #Nome do banco
       networks:
         - rasa-net
 
@@ -76,6 +96,8 @@ networks:
   rasa-net:
     driver: bridge
 
+volumes:
+  mysql-volume:
 
 
 

--- a/mysql/inicial.sql
+++ b/mysql/inicial.sql
@@ -1,0 +1,17 @@
+CREATE DATABASE IF NOT EXISTS Cisam;
+
+SET character_set_client = utf8;
+SET character_set_connection = utf8;
+SET character_set_results = utf8;
+SET collation_connection = utf8_general_ci;
+
+
+USE Cisam;
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS `UserCisam` (
+    `user_lgpd` VARCHAR(50) NOT NULL,
+    `user_prontuario` VARCHAR(50) NOT NULL,
+
+     PRIMARY KEY (`user_prontuario`)
+);


### PR DESCRIPTION
## Descrição

### domain.yml
Ajustado: diversas utters foram ajustadas;
Adicionado: utter tipo button para análise;
Adicionado: action_reset_slots para resetar todos os slots ao final do diálogo;
Removido: action_exemplo (slots/form/action) - **sem uso**;
Removido: validate_consulta_form (slots/form/action) - **sem uso**.

### rules.yml
Adicionado: action_reset_slots para resetar todos os slots ao final do diálogo;
Removido:  exemplo_forms - **sem uso**.

### validate_slots.py
Adicionado: action_reset_slots para resetar todos os slots ao final do diálogo;
Removido: validate_consulta_form (slots/form/action)  - **sem uso**;
Removido: função teste (user_lgpd e user_prontuario) que estava duplicada.

### stories.yml
Removido action_exemplo para não conflitar com domain - **sem uso**. 


